### PR TITLE
Fixed issue where font resources for differing labels would cause ker…

### DIFF
--- a/src/base-layers/labels/label-layer.ts
+++ b/src/base-layers/labels/label-layer.ts
@@ -579,7 +579,10 @@ export class LabelLayer<
     if (labelKerningRequest) {
       // If the request already embodies the request for the text, we just see if the
       // font map has been provided yet to indicate if the kerning information is ready
-      if (labelKerningRequest.kerningPairs === checkText) {
+      if (
+        labelKerningRequest.kerningPairs &&
+        labelKerningRequest.kerningPairs.indexOf(checkText) > -1
+      ) {
         return Boolean(labelKerningRequest.fontMap);
       }
 
@@ -618,7 +621,7 @@ export class LabelLayer<
       // Make the request for retrieving the kerning information.
       labelKerningRequest = fontRequest({
         character: "",
-        kerningPairs: checkText,
+        kerningPairs: [checkText],
         metrics
       });
 

--- a/src/resources/text/font-manager.ts
+++ b/src/resources/text/font-manager.ts
@@ -282,20 +282,20 @@ export class FontManager {
     const fontMap = this.fontMaps.get(resourceKey);
     if (!fontMap) return;
 
-    let allPairs = "";
+    let allPairs: string[] = [];
     const allCharacters = new Set<string>();
 
     // Aggregate all kerning and character requests and needs
     for (let i = 0, iMax = requests.length; i < iMax; ++i) {
       const req = requests[i];
       if (req.character) allCharacters.add(req.character);
-      if (req.kerningPairs) allPairs += req.kerningPairs;
+      if (req.kerningPairs) allPairs = allPairs.concat(req.kerningPairs);
 
       // We add in truncation characters as well if provided
       if (req.metrics) {
         if (req.metrics.truncation) {
           const truncation = req.metrics.truncation.replace(/\s/g, "");
-          allPairs += truncation;
+          allPairs.push(truncation);
 
           for (let i = 0, iMax = req.metrics.truncation.length; i < iMax; ++i) {
             allCharacters.add(truncation);
@@ -328,7 +328,7 @@ export class FontManager {
   /**
    * This updates the calculated kerning pairs for a given font map.
    */
-  private async updateKerningPairs(pairs: string, fontMap?: FontMap) {
+  private async updateKerningPairs(pairs: string[], fontMap?: FontMap) {
     if (!fontMap) return;
 
     // Calculate the new kerning pair information

--- a/src/resources/text/font-map.ts
+++ b/src/resources/text/font-map.ts
@@ -361,7 +361,7 @@ export class FontMap extends IdentifyByKey implements IFontResourceOptions {
           !this.kerning[lastChar][firstTruncChar]
         ) {
           const kerning = await fontRenderer.estimateKerning(
-            lastChar + firstTruncChar,
+            [lastChar + firstTruncChar],
             this.fontString,
             this.fontSource.size,
             this.kerning,

--- a/src/resources/text/font-renderer.ts
+++ b/src/resources/text/font-renderer.ts
@@ -299,11 +299,15 @@ async function renderEachPair(
 /**
  * This function takes a string to return a map with next letters of each letter
  */
-function stringToPairs(str: string, existing: KerningPairs): KerningInfo {
+function stringToPairs(
+  str: string,
+  existing: KerningPairs,
+  out?: KerningInfo
+): KerningInfo {
   // Remove all the whitespace
   str = str.replace(/\s/g, "");
-  const all: string[] = [];
-  const pairs: KerningPairs = {};
+  const all: string[] = (out && out.all) || [];
+  const pairs: KerningPairs = (out && out.pairs) || {};
 
   for (let i = 0; i < str.length - 1; i++) {
     const left = str[i];
@@ -382,15 +386,24 @@ export class FontRenderer {
    * the distance from a 'left' letter's top left  corner to the 'right' letter's topleft corner.
    */
   async estimateKerning(
-    str: string,
+    str: string[],
     fontString: string,
     fontSize: number,
     existing: KerningPairs,
     includeSpace: boolean
   ) {
     // Get all of the new pairs of letters that need kerning infoz
-    const pairInfo = stringToPairs(str, existing);
-    debug("Estimating Kerning for", str);
+    const pairInfo: KerningInfo = {
+      all: [],
+      pairs: {},
+      spaceWidth: 0
+    };
+
+    for (let i = 0, iMax = str.length; i < iMax; ++i) {
+      const s = str[i];
+      debug("Estimating Kerning for", s);
+      stringToPairs(s, existing, pairInfo);
+    }
 
     // Only if there are new kerning needs do we actually need to run this method
     if (pairInfo.all.length > 0) {

--- a/src/resources/text/font-resource-manager.ts
+++ b/src/resources/text/font-resource-manager.ts
@@ -49,8 +49,12 @@ export interface IFontResourceRequest extends BaseResourceRequest {
    * needed for the requester to get the information needed.
    */
   fontMap?: FontMap;
-  /** The characters for which we want to have the kerning information retrieved. */
-  kerningPairs?: string;
+  /**
+   * The characters for which we want to have the kerning information retrieved. This will be applied as a list of words
+   * for which we want the kerning information. We do this to prevent concating the words into a single string which can
+   * make it really difficult to preload all possible label combinations.
+   */
+  kerningPairs?: string[];
   /** When provided, the request will fill in the metrics for the input parameters */
   metrics?: {
     /** The desired font size for the layout */


### PR DESCRIPTION
fixed: Kerning is no longer calculated between characters of unrelated labels. This makes it easier to warm up an environment with the expected labels to be in use.