### PR TITLE
Added in maxScale capability to allow for larger source glyphs render…

### DIFF
--- a/src/base-layers/labels/glyph-instance.ts
+++ b/src/base-layers/labels/glyph-instance.ts
@@ -31,6 +31,8 @@ export class GlyphInstance extends Instance {
    * is rendered at 32px, then this needs to be 20 / 32 to render the glyph at a font size of 20.
    */
   @observable fontScale: number = 1;
+  /** When in BOUND_MAX mode, this controls how much scaling is allowed up to the base font size */
+  @observable maxScale: number = 1;
   /** The top left location of this glyph's offset from it's origin */
   @observable offset: Vec2 = [0, 0];
   /** This is the anchor point of the glyph to which the glyph scales and rotates about and is positioned */
@@ -52,6 +54,9 @@ export class GlyphInstance extends Instance {
     this.offset = options.offset || this.offset;
     this.character = options.character || this.character;
     this.color = options.color || this.color;
+    this.maxScale = options.maxScale || this.maxScale;
+    this.padding = options.padding || this.padding;
+    this.anchor = options.anchor || this.anchor;
     this.onReady = options.onReady;
   }
 

--- a/src/base-layers/labels/glyph-layer-bound-max.vs
+++ b/src/base-layers/labels/glyph-layer-bound-max.vs
@@ -7,19 +7,19 @@ void main() {
   ${attributes}
 
   vec2 scale = fontScale * cameraScale.xy;
-  float maxScale = max(scale.x, scale.y);
+  float scaleBy = max(scale.x, scale.y) / maxScale;
   vec2 pushOut = normals * glyphSize * fontScale;
 
   float vx = mix(
     (-anchor.x + offset.x + pushOut.x),
-    (-anchor.x + offset.x + pushOut.x) / maxScale,
-    float(scale.x >= 1.0)
+    (-anchor.x + offset.x + pushOut.x) / scaleBy,
+    float(scale.x >= maxScale)
   );
 
   float vy = mix(
     (-anchor.y + offset.y + pushOut.y),
-    (-anchor.y + offset.y + pushOut.y) / maxScale,
-    float(scale.y >= 1.0)
+    (-anchor.y + offset.y + pushOut.y) / scaleBy,
+    float(scale.y >= maxScale)
   );
 
   // Calculate in the anchor, the origin, glyph offset, and the quad pushout to make our quad geometry

--- a/src/base-layers/labels/glyph-layer.ts
+++ b/src/base-layers/labels/glyph-layer.ts
@@ -233,6 +233,11 @@ export class GlyphLayer<
           size: InstanceAttributeSize.TWO,
           update: o => o.padding
         },
+        {
+          name: "maxScale",
+          size: InstanceAttributeSize.ONE,
+          update: o => [o.maxScale]
+        },
         glyphSizeAttr,
         glyphTextureAttr
       ],

--- a/src/base-layers/labels/label-instance.ts
+++ b/src/base-layers/labels/label-instance.ts
@@ -48,13 +48,13 @@ export class LabelInstance extends Instance {
   /** Depth sorting of the label (or the z value of the label) */
   @observable depth: number = 0;
   /**
-   * Font size in pixels. This causes scaling relative to the base font resource available.
+   * Font size in world coordinates. This causes scaling relative to the base font resource available.
    * IE- If the font resource is rendered at 32 and this is 16, then the output rendering will
    *     be glyphs that are 50% the size of the rendered glyph in the font map. This can cause
    *     artefacts based on the rendering strategy used.
    */
   @observable fontSize: number = 12;
-  /** When in BOUND_MAX mode, this allows the label to scale up beyond it's max size */
+  /** When in BOUND_MAX mode, this controls how much scaling is allowed up to the base font size */
   @observable maxScale: number = 1;
   /**
    * This is the maximum width the label can take up. If this is exceeded the label gets truncated.

--- a/src/base-layers/labels/label-layer.ts
+++ b/src/base-layers/labels/label-layer.ts
@@ -306,7 +306,8 @@ export class LabelLayer<
         "color",
         "origin",
         "fontSize",
-        "maxWidth"
+        "maxWidth",
+        "maxScale"
       ]);
     }
 
@@ -317,7 +318,8 @@ export class LabelLayer<
       color: colorId,
       origin: originId,
       fontSize: fontSizeId,
-      maxWidth: maxWidthId
+      maxWidth: maxWidthId,
+      maxScale: maxScaleId
     } = this.propertyIds;
 
     for (let i = 0, iMax = changes.length; i < iMax; ++i) {
@@ -355,6 +357,10 @@ export class LabelLayer<
 
           if (changed[originId] !== undefined) {
             this.updateGlyphOrigins(instance);
+          }
+
+          if (changed[maxScaleId] !== undefined) {
+            this.updateGlyphMaxScales(instance);
           }
 
           if (changed[fontSizeId] !== undefined) {
@@ -516,6 +522,7 @@ export class LabelLayer<
       glyph.anchor = [anchor.x || 0, anchor.y || 0];
       glyph.origin = copy2(instance.origin);
       glyph.padding = padding || [0, 0];
+      glyph.maxScale = instance.maxScale;
     }
   }
 
@@ -614,6 +621,7 @@ export class LabelLayer<
           character: char,
           color: instance.color,
           origin: instance.origin,
+          maxScale: instance.maxScale,
           onReady: this.handleGlyphReady
         });
 
@@ -670,6 +678,20 @@ export class LabelLayer<
 
     for (let i = 0, iMax = glyphs.length; i < iMax; ++i) {
       glyphs[i].origin = [origin[0], origin[1]];
+    }
+  }
+
+  /**
+   * This updates all of the glyphs for the label to have the same position
+   * as the label.
+   */
+  updateGlyphMaxScales(instance: T) {
+    const glyphs = instance.glyphs;
+    if (!glyphs) return;
+    const maxScale = instance.maxScale;
+
+    for (let i = 0, iMax = glyphs.length; i < iMax; ++i) {
+      glyphs[i].maxScale = maxScale;
     }
   }
 

--- a/test/nodes-edges/nodes-edges.ts
+++ b/test/nodes-edges/nodes-edges.ts
@@ -309,6 +309,7 @@ export class NodesEdges extends BaseDemo {
       text: txt !== undefined ? txt : words.join(" "),
       fontSize: this.parameters.fontSize,
       onReady: this.labelReady,
+      maxScale: 0.5,
       preload
     });
 

--- a/test/types.ts
+++ b/test/types.ts
@@ -47,7 +47,7 @@ export const DEFAULT_RESOURCES = {
     key: "test-font",
     fontSource: {
       localKerningCache: true,
-      size: 32,
+      size: 64,
       family: "Lucida Grande",
       type: FontMapGlyphType.BITMAP,
       weight: "normal"


### PR DESCRIPTION
fixed: maxScale capabilities added back in for BOUND_MAX scale mode which allows for better controls to prevent a font from scaling up too much to keep it crisp.