### PR TITLE
Reactivated instances update full property list to resync with change…

### DIFF
--- a/src/instance-provider/instance.ts
+++ b/src/instance-provider/instance.ts
@@ -18,7 +18,12 @@ export class Instance implements Identifiable {
   }
 
   /** This indicates when the instance is active / rendering */
-  @observable active: boolean;
+  get active() { return this._active; }
+  set active(val: boolean) {
+    this._active = val;
+    this.reactivate = true;
+  }
+  @observable _active: boolean;
   /** The property changes on the instance */
   changes: { [key: number]: number } = {};
   /**
@@ -38,6 +43,8 @@ export class Instance implements Identifiable {
   observableStorage: any[] = [];
   /** A numerical look up for the instance. Numerical identifiers run faster than objects or strings */
   @observable private _uid = Instance.newUID;
+  /** This is the flag indicating this instance was reactivated. When true, this performs a full update of all properties on the instance */
+  reactivate: boolean = false;
 
   /**
    * Retrieves a method for disposing the link between observables and observer.

--- a/src/surface/buffer-management/instance-attribute-buffering/instance-attribute-diff-processor.ts
+++ b/src/surface/buffer-management/instance-attribute-buffering/instance-attribute-diff-processor.ts
@@ -148,7 +148,7 @@ export class InstanceAttributeDiffProcessor<
 
     if (instance.active) {
       // If no prop ids provided, then we perform a complete instance property update
-      if (propIds.length === 0) {
+      if (propIds.length === 0 || instance.reactivate) {
         propIds = this.bufferManager.getUpdateAllPropertyIdList();
       }
 
@@ -237,7 +237,7 @@ export class InstanceAttributeDiffProcessor<
 
     if (instance.active) {
       // If no prop ids provided, then we perform a complete instance property update
-      if (propIds.length === 0) {
+      if (propIds.length === 0 || instance.reactivate) {
         propIds = this.bufferManager.getUpdateAllPropertyIdList();
       }
 

--- a/src/surface/buffer-management/uniform-buffering/uniform-diff-processor.ts
+++ b/src/surface/buffer-management/uniform-buffering/uniform-diff-processor.ts
@@ -81,6 +81,8 @@ export class UniformDiffProcessor<T extends Instance> extends BaseDiffProcessor<
   }
 
   /**
+   * TODO: We should be updating based on prop ids instead of always updating all props for every change.
+   *
    * This performs the actual updating of buffers the instance needs to update
    */
   updateInstance(
@@ -95,7 +97,7 @@ export class UniformDiffProcessor<T extends Instance> extends BaseDiffProcessor<
       let instanceUniform, value, block, start;
       let k: number, endk;
 
-      // Loop through the instance attributes and update the uniform cluster with the valaues
+      // Loop through the instance attributes and update the uniform cluster with the values
       // Calculated for the instance
       for (let i = 0, end = layer.instanceAttributes.length; i < end; ++i) {
         instanceUniform = layer.instanceAttributes[i];


### PR DESCRIPTION
fixed: Reactivating an instance (without removing and adding to a provider) now properly syncs all attributes upon reactivation. This ensures changes made while inactive are properly synced with the buffer after made active again.