### PR TITLE
Version of deltav is now embedded into the generated canvas

### DIFF
--- a/scripts/release.js
+++ b/scripts/release.js
@@ -1,4 +1,4 @@
-const { removeSync, copySync } = require('fs-extra');
+const { removeSync, copySync, existsSync, writeJSONSync, readJSONSync } = require('fs-extra');
 const { resolve } = require('path');
 const shell = require('shelljs');
 
@@ -143,5 +143,19 @@ if (!TEST) {
   if (shell.exec(`git push ${ENSURE_REMOTE} ${version}`).code !== 0) {
     console.log('Could not push tag to the remote repository');
     process.exit(1);
+  }
+
+  // Update the release version json in the source
+  if (existsSync(resolve('src/release.json'))) {
+    try {
+      const contents = readJSONSync(resolve('src/release.json'));
+      contents.version = version;
+      writeJSONSync(resolve('src/release.json'), contents);
+    }
+
+    catch (err) {
+      console.log('Could not update the release.json file with current library version.');
+      process.exit(1);
+    }
   }
 }

--- a/src/surface/surface.ts
+++ b/src/surface/surface.ts
@@ -1114,6 +1114,13 @@ export class Surface {
     const canvas = options.context;
     if (!canvas) return null;
 
+    // Apply the deltav version to the attributes of the canvas so we have more debugging information available
+    try {
+      canvas.setAttribute("data-deltav", require("../release").version);
+    } catch (err) {
+      // NOOP - We want the application of the version to happen, but it is not application critical
+    }
+
     // Get the starting width and height so adjustments don't affect it
     const width = canvas.width;
     const height = canvas.height;


### PR DESCRIPTION
fixed: The version deltav is using is now embedded into the canvas it generates as a data attribute. Will be useful for debugging purposes.